### PR TITLE
Fix initialising text controller

### DIFF
--- a/open_earable/lib/controls_tab/views/audio_player.dart
+++ b/open_earable/lib/controls_tab/views/audio_player.dart
@@ -31,6 +31,8 @@ class _AudioPlayerCardState extends State<AudioPlayerCard> {
     super.initState();
     _filenameTextController = TextEditingController(
         text: "${OpenEarableSettings().selectedFilename}");
+    _jingleTextController = TextEditingController(
+        text: "${OpenEarableSettings().selectedJingle}");
     _frequencyTextController = TextEditingController(
         text: "${OpenEarableSettings().selectedFrequency}");
     _frequencyVolumeTextController = TextEditingController(


### PR DESCRIPTION
```
The following LateError was thrown while handling a gesture:
LateInitializationError: Field '_jingleTextController@101399675' has not been initialized.

When the exception was thrown, this was the stack:
#0      _AudioPlayerCardState._jingleTextController (package:open_earable/controls_tab/views/audio_player.dart)
#1      _AudioPlayerCardState._setJingle (package:open_earable/controls_tab/views/audio_player.dart:85:46)
#2      _AudioPlayerCardState._setSourceButtonPressed (package:open_earable/controls_tab/views/audio_player.dart:76:9)
#3      _InkResponseState.handleTap (package:flutter/src/material/ink_well.dart:1170:21)
#4      GestureRecognizer.invokeCallback (package:flutter/src/gestures/recognizer.dart:351:24)
#5      TapGestureRecognizer.handleTapUp (package:flutter/src/gestures/tap.dart:656:11)
#6      BaseTapGestureRecognizer._checkUp (package:flutter/src/gestures/tap.dart:313:5)
#7      BaseTapGestureRecognizer.acceptGesture (package:flutter/src/gestures/tap.dart:283:7)
#8      GestureArenaManager.sweep (package:flutter/src/gestures/arena.dart:169:27)
#9      GestureBinding.handleEvent (package:flutter/src/gestures/binding.dart:505:20)
#10     GestureBinding.dispatchEvent (package:flutter/src/gestures/binding.dart:481:22)
#11     RendererBinding.dispatchEvent (package:flutter/src/rendering/binding.dart:450:11)
#12     GestureBinding._handlePointerEventImmediately (package:flutter/src/gestures/binding.dart:426:7)
#13     GestureBinding.handlePointerEvent (package:flutter/src/gestures/binding.dart:389:5)
#14     GestureBinding._flushPointerEventQueue (package:flutter/src/gestures/binding.dart:336:7)
#15     GestureBinding._handlePointerDataPacket (package:flutter/src/gestures/binding.dart:305:9)
#16     _invoke1 (dart:ui/hooks.dart:328:13)
#17     PlatformDispatcher._dispatchPointerDataPacket (dart:ui/platform_dispatcher.dart:442:7)
#18     _dispatchPointerDataPacket (dart:ui/hooks.dart:262:31)
```