### PR TITLE
These changes maybe should be implemented in open_earable_flutter? Or merged here

### DIFF
--- a/open_wearable/lib/main.dart
+++ b/open_wearable/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'package:go_router/go_router.dart';
 import 'package:open_earable_flutter/open_earable_flutter.dart' hide logger;
+import 'package:universal_ble/universal_ble.dart';
 import 'package:open_wearable/models/app_background_execution_bridge.dart';
 import 'package:open_wearable/models/app_launch_session.dart';
 import 'package:open_wearable/models/app_shutdown_settings.dart';
@@ -67,7 +68,9 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   late final StreamSubscription _unsupportedFirmwareSub;
   late final StreamSubscription _wearableEventSub;
+  late final StreamSubscription<AvailabilityState> _bleAvailabilitySub;
   late final BluetoothAutoConnector _autoConnector;
+  late final WearableConnector _wearableConnector;
   late final Future<SharedPreferences> _prefsFuture;
   late final StreamSubscription _wearableProvEventSub;
   late final WearablesProvider _wearablesProvider;
@@ -79,6 +82,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   bool _backgroundExecutionRequestedForShutdown = false;
   bool _backgroundExecutionRequestedForRecording = false;
   bool _isBackgroundExecutionActive = false;
+  bool _isBluetoothPoweredOn = true;
 
   static const Duration _closeShutdownGracePeriod = Duration(
     seconds: 10,
@@ -216,7 +220,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
       );
     });
 
-    final WearableConnector connector = context.read<WearableConnector>();
+    _wearableConnector = context.read<WearableConnector>();
 
     _autoConnector = BluetoothAutoConnector(
       navStateGetter: () => rootNavigatorKey.currentState,
@@ -227,8 +231,17 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
     AutoConnectPreferences.autoConnectEnabledListenable.addListener(
       _syncAutoConnectorWithSetting,
     );
+    _bleAvailabilitySub = UniversalBle.availabilityStream.listen(
+      _handleBleAvailabilityChanged,
+      onError: (error, stackTrace) {
+        logger.w(
+          'Failed to observe Bluetooth availability updates: $error\n$stackTrace',
+        );
+      },
+    );
+    unawaited(_syncInitialBluetoothAvailability());
 
-    _wearableEventSub = connector.events.listen((event) {
+    _wearableEventSub = _wearableConnector.events.listen((event) {
       if (event is WearableConnectEvent) {
         _handleWearableConnected(event.wearable);
       }
@@ -238,11 +251,59 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   }
 
   void _syncAutoConnectorWithSetting() {
-    if (AutoConnectPreferences.autoConnectEnabled) {
+    if (AutoConnectPreferences.autoConnectEnabled && _isBluetoothPoweredOn) {
       _autoConnector.start();
       return;
     }
     _autoConnector.stop();
+  }
+
+  Future<void> _syncInitialBluetoothAvailability() async {
+    try {
+      final state = await UniversalBle.getBluetoothAvailabilityState();
+      if (!mounted) {
+        return;
+      }
+      _handleBleAvailabilityChanged(state);
+    } catch (error, stackTrace) {
+      logger.w(
+        'Failed to read initial Bluetooth availability state: $error\n$stackTrace',
+      );
+    }
+  }
+
+  void _handleBleAvailabilityChanged(AvailabilityState state) {
+    final wasPoweredOn = _isBluetoothPoweredOn;
+    _isBluetoothPoweredOn = state == AvailabilityState.poweredOn;
+
+    if (_isBluetoothPoweredOn) {
+      if (!wasPoweredOn) {
+        logger.i('Bluetooth powered on. Resuming connection flows.');
+      }
+      _syncAutoConnectorWithSetting();
+      return;
+    }
+
+    _autoConnector.stop();
+
+    if (state == AvailabilityState.poweredOff) {
+      logger.i('Bluetooth powered off. Clearing connected wearable UI state.');
+      _wearableConnector.clearTrackedConnections();
+      _removeAllConnectedWearablesFromUiState();
+    }
+  }
+
+  void _removeAllConnectedWearablesFromUiState() {
+    final connectedWearables =
+        List<Wearable>.from(_wearablesProvider.wearables);
+    if (connectedWearables.isEmpty) {
+      return;
+    }
+
+    for (final wearable in connectedWearables) {
+      _wearablesProvider.removeWearable(wearable);
+      _sensorRecorderProvider.removeWearable(wearable);
+    }
   }
 
   void _handleWearableConnected(Wearable wearable) {
@@ -620,6 +681,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   void dispose() {
     _unsupportedFirmwareSub.cancel();
     _wearableEventSub.cancel();
+    _bleAvailabilitySub.cancel();
     _wearableProvEventSub.cancel();
     AutoConnectPreferences.autoConnectEnabledListenable.removeListener(
       _syncAutoConnectorWithSetting,

--- a/open_wearable/lib/models/wearable_connector.dart
+++ b/open_wearable/lib/models/wearable_connector.dart
@@ -70,6 +70,20 @@ class WearableConnector {
     connectedWearables.forEach(_handleConnection);
   }
 
+  /// Clears local connection bookkeeping.
+  ///
+  /// Useful when the platform Bluetooth adapter is powered off and the
+  /// platform stack does not emit per-device disconnect callbacks.
+  void clearTrackedConnections({Iterable<String>? deviceIds}) {
+    if (deviceIds == null) {
+      _trackedWearableIds.clear();
+      return;
+    }
+    for (final id in deviceIds) {
+      _trackedWearableIds.remove(id);
+    }
+  }
+
   void _handleConnection(Wearable wearable) {
     if (_trackedWearableIds.contains(wearable.deviceId)) {
       return;

--- a/open_wearable/lib/widgets/devices/connect_devices_page.dart
+++ b/open_wearable/lib/widgets/devices/connect_devices_page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'package:open_earable_flutter/open_earable_flutter.dart' hide logger;
+import 'package:universal_ble/universal_ble.dart';
 import 'package:open_wearable/models/connect_devices_scan_session.dart';
 import 'package:open_wearable/models/device_name_formatter.dart';
 import 'package:open_wearable/models/wearable_display_group.dart';
@@ -337,15 +338,27 @@ class _ConnectDevicesPageState extends State<ConnectDevicesPage> {
     setState(() {
       _connectingDevices[device.id] = true;
     });
+    final connector = context.read<WearableConnector>();
 
     try {
-      final connector = context.read<WearableConnector>();
       await connector.connect(device);
       ConnectDevicesScanSession.removeDiscoveredDevice(device.id);
     } catch (e, stackTrace) {
       if (_isAlreadyConnectedError(e, device)) {
         logger.i(
-          'Device ${device.id} already connected. Refreshing connected devices.',
+          'Device ${device.id} already connected. Attempting stale-connection recovery.',
+        );
+        final recovered = await _recoverFromStaleConnectionState(
+          device: device,
+          connector: connector,
+        );
+        if (recovered) {
+          ConnectDevicesScanSession.removeDiscoveredDevice(device.id);
+          return;
+        }
+
+        logger.i(
+          'Stale-connection recovery failed for ${device.id}. Refreshing connected system devices.',
         );
         await _pullConnectedSystemDevices();
         ConnectDevicesScanSession.removeDiscoveredDevice(device.id);
@@ -397,6 +410,60 @@ class _ConnectDevicesPageState extends State<ConnectDevicesPage> {
       await context.read<WearableConnector>().connectToSystemDevices();
     } catch (error, stackTrace) {
       logger.w('Failed to pull connected system devices: $error\n$stackTrace');
+    }
+  }
+
+  Future<bool> _recoverFromStaleConnectionState({
+    required DiscoveredDevice device,
+    required WearableConnector connector,
+  }) async {
+    try {
+      await UniversalBle.disconnect(device.id);
+    } catch (error, stackTrace) {
+      logger.d(
+        'Low-level disconnect attempt for ${device.id} failed during stale recovery: $error\n$stackTrace',
+      );
+    }
+
+    if (await _retryConnectorConnect(device: device, connector: connector)) {
+      return true;
+    }
+
+    try {
+      await UniversalBle.connect(device.id);
+      await UniversalBle.connectionStream(device.id)
+          .firstWhere((isConnected) => isConnected)
+          .timeout(Duration(seconds: 2));
+    } catch (error, stackTrace) {
+      logger.d(
+        'Low-level connect probe for ${device.id} did not complete during stale recovery: $error\n$stackTrace',
+      );
+    } finally {
+      try {
+        await UniversalBle.disconnect(device.id);
+      } catch (error, stackTrace) {
+        logger.d(
+          'Low-level disconnect probe for ${device.id} failed during stale recovery: $error\n$stackTrace',
+        );
+      }
+    }
+
+    await Future<void>.delayed(Duration(milliseconds: 250));
+    return _retryConnectorConnect(device: device, connector: connector);
+  }
+
+  Future<bool> _retryConnectorConnect({
+    required DiscoveredDevice device,
+    required WearableConnector connector,
+  }) async {
+    try {
+      await connector.connect(device);
+      return true;
+    } catch (error, stackTrace) {
+      logger.d(
+        'Connector retry for ${device.id} failed during stale recovery: $error\n$stackTrace',
+      );
+      return false;
     }
   }
 

--- a/open_wearable/pubspec.lock
+++ b/open_wearable/pubspec.lock
@@ -966,7 +966,7 @@ packages:
     source: hosted
     version: "1.4.0"
   universal_ble:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: universal_ble
       sha256: "6a5c6c1fb295015934a5aef3dc751ae7e00721535275f8478bfe74db77b238c5"

--- a/open_wearable/pubspec.yaml
+++ b/open_wearable/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   open_file: ^3.3.2
   open_earable_flutter: ^2.3.4
+  universal_ble: ^0.21.1
   flutter_platform_widgets: ^9.0.0
   provider: ^6.1.2
   logger: ^2.5.0


### PR DESCRIPTION
Fix bugs: On iOS, the app showed that the earable is still connected after BLE is turned off. After turning back on the bluetooth, the app wasn't able to reconnect to the earable. Auto reconnect is still not working the fist time after bluetooth restart