### PR TITLE
[codex] ci(android): approve release version bump PR

### DIFF
--- a/.github/workflows/android_build_and_deploy.yaml
+++ b/.github/workflows/android_build_and_deploy.yaml
@@ -121,6 +121,10 @@ jobs:
             --title "$commit_message" \
             --body "Bumps the app version after the production Play Store release.")
 
+          gh pr review "$pr_url" \
+            --approve \
+            --body "Automated approval for version bump after production release."
+
           gh pr merge "$pr_url" \
             --squash \
             --delete-branch \


### PR DESCRIPTION
## Summary
- Add an explicit `gh pr review --approve` step before auto-merging the production release version-bump PR.
- Uses the GitHub Actions PR approval permission that is now enabled for this repository.

## Why
The production Android deploy workflow successfully uploads to Google Play, then creates a version-bump PR, but auto-merge fails with:

`GraphQL: At least 1 approving review is required by reviewers with write access. (mergePullRequest)`

The workflow created the PR and immediately tried to merge it without submitting an approval.

## Validation
- `git diff --check origin/main...HEAD -- .github/workflows/android_build_and_deploy.yaml`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/android_build_and_deploy.yaml'); puts 'yaml ok'"`

## Notes
If branch protection still requires approval from someone other than the last pusher, this may still need a separate machine-user/App token or a bypass actor. This change addresses the currently observed missing-approval error.
