### PR TITLE
Apply edge recorder prefix to stereo pairs

### DIFF
--- a/open_wearable/lib/widgets/sensors/configuration/edge_recorder_prefix_row.dart
+++ b/open_wearable/lib/widgets/sensors/configuration/edge_recorder_prefix_row.dart
@@ -6,9 +6,14 @@ import 'package:open_earable_flutter/open_earable_flutter.dart';
 /// Row that shows the current file prefix of an [EdgeRecorderManager]
 /// and lets the user change it.
 class EdgeRecorderPrefixRow extends StatefulWidget {
-  const EdgeRecorderPrefixRow({super.key, required this.manager});
+  const EdgeRecorderPrefixRow({
+    super.key,
+    required this.manager,
+    this.pairedManager,
+  });
 
   final EdgeRecorderManager manager;
+  final EdgeRecorderManager? pairedManager;
 
   @override
   State<EdgeRecorderPrefixRow> createState() => _RecorderPrefixRowState();
@@ -83,7 +88,12 @@ class _RecorderPrefixRowState extends State<EdgeRecorderPrefixRow> {
     );
 
     if (result == true) {
-      await widget.manager.setFilePrefix(_editPrefixController.text.trim());
+      final prefix = _editPrefixController.text.trim();
+      await Future.wait([
+        widget.manager.setFilePrefix(prefix),
+        if (widget.pairedManager != null)
+          widget.pairedManager!.setFilePrefix(prefix),
+      ]);
       if (!mounted) {
         return;
       }

--- a/open_wearable/lib/widgets/sensors/configuration/sensor_configuration_device_row.dart
+++ b/open_wearable/lib/widgets/sensors/configuration/sensor_configuration_device_row.dart
@@ -384,10 +384,15 @@ class _SensorConfigurationDeviceRowState
     ];
 
     if (device.hasCapability<EdgeRecorderManager>()) {
+      final pairedEdgeRecorderManager = widget.pairedDevice != null &&
+              widget.pairedDevice!.hasCapability<EdgeRecorderManager>()
+          ? widget.pairedDevice!.requireCapability<EdgeRecorderManager>()
+          : null;
       content.addAll([
         const InsetSectionDivider(),
         EdgeRecorderPrefixRow(
           manager: device.requireCapability<EdgeRecorderManager>(),
+          pairedManager: pairedEdgeRecorderManager,
         ),
       ]);
     }

--- a/open_wearable/test/widgets/sensors/configuration/edge_recorder_prefix_row_test.dart
+++ b/open_wearable/test/widgets/sensors/configuration/edge_recorder_prefix_row_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:open_earable_flutter/open_earable_flutter.dart';
+import 'package:open_wearable/widgets/sensors/configuration/edge_recorder_prefix_row.dart';
+
+void main() {
+  testWidgets('sets filename prefix on both paired edge recorder managers',
+      (tester) async {
+    final primaryManager = _FakeEdgeRecorderManager('');
+    final pairedManager = _FakeEdgeRecorderManager('');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: EdgeRecorderPrefixRow(
+            manager: primaryManager,
+            pairedManager: pairedManager,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('On-Device Filename Prefix'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'session_01');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(primaryManager.prefix, 'session_01');
+    expect(pairedManager.prefix, 'session_01');
+  });
+}
+
+class _FakeEdgeRecorderManager implements EdgeRecorderManager {
+  _FakeEdgeRecorderManager(this.prefix);
+
+  String prefix;
+
+  @override
+  Future<String> get filePrefix async => prefix;
+
+  @override
+  Future<void> setFilePrefix(String prefix) async {
+    this.prefix = prefix;
+  }
+}


### PR DESCRIPTION
## Summary
- Pass the paired edge recorder manager into the on-device filename prefix row for combined stereo pairs
- Save filename prefix changes to both primary and paired devices when available
- Add a widget regression test that verifies paired managers receive the same prefix

## Tests
- flutter test test/widgets/sensors/configuration/edge_recorder_prefix_row_test.dart
- flutter analyze